### PR TITLE
Add -e to exec single test in shell

### DIFF
--- a/bin/ts
+++ b/bin/ts
@@ -318,10 +318,7 @@ ts_run_test_suite () {
 
     if [ execute = "$TS_REPORT" ]
     then
-      if [ verbose = "$TS_MODE" ]
-      then ts_run_test
-      else ts_run_test 2>/dev/null
-      fi
+      ts_run_test
       exit $?
     fi
 


### PR DESCRIPTION
This is super-useful as a debugging tool.  I've really enjoyed having it and miss it when it's gone.  Current problems making this a work-in-progress:
- The exit status of the test is not reflected in the shell.  This arises because currently `-e` does not use a true exec, instead it runs the test within the normal pipeline and simply turns off post-processing of the output.  This is good for seeing the output but is a bit of a lie.
- No tests!
