### PR TITLE
Provide ts_skip()

### DIFF
--- a/bin/ts
+++ b/bin/ts
@@ -93,11 +93,16 @@ TS_REMOVE_TMP_DIR=${TS_REMOVE_TMP_DIR:-false}
 TS_PASS="${TS_PASS:-[32m}"
 TS_FAIL="${TS_FAIL:-[1;31m}"
 TS_NORM="${TS_NORM:-[0m}"
-TS_NOEX="${TS_NOEX:-[1;33m}"
+TS_SKIP="${TS_SKIP:-[1;33m}"
 
 mkdir -p "$TS_TMP_DIR"
 ts_status_file="$TS_TMP_DIR/status"
 ts_monitor_file="$TS_TMP_DIR/monitor"
+ts_skip_file="$TS_TMP_DIR/skips"
+ts_test_name=""
+
+# If there is a leftover skip file, remove that.
+rm "$ts_skip_file" 2>/dev/null
 
 if [ execute = "$TS_REPORT" ] && [ ts = "$ts_progname" ]
 then
@@ -172,12 +177,12 @@ function format (status, descr, bytes) {
   readbytes(bytes)
   printf("\n")
 }
-BEGIN { npass=nfail=0 }
+BEGIN { npass=nskip=nfail=0 }
 /^\[/ { descr=$0 }
 /^P/  { format("P", descr, $2); fflush(); npass++; }
 /^F/  { format("F", descr, $2); fflush(); nfail++; }
-/^X/  { format("X", descr, $2); fflush(); nfail++; }
-END   { printf("%d %d\n", npass, nfail) >> status_file }
+/^S/  { format("S", descr, $2); fflush(); nskip++; }
+END   { printf("%d %d %d\n", npass, nfail, nskip) >> status_file }
 '
 }
 
@@ -189,7 +194,7 @@ ts_monitor () {
     { print $0 "\n" >> monitor_file };
     /^P/ { print "."; fflush() };
     /^F/ { print "F"; fflush() };
-    /^X/ { print "-"; fflush() };
+    /^S/ { print "-"; fflush() };
   ' >&2
   printf "\n\n" >&2
 
@@ -199,7 +204,7 @@ ts_monitor () {
 # Filters passing tests from the ts stream format.
 ts_filter () {
   if [ true = "$TS_FILTER" ]
-  then awk $ts_awk_opts '/^[FX] /,/^$/ { print $0; fflush(); }'
+  then awk $ts_awk_opts '/^[FS] /,/^$/ { print $0; fflush(); }'
   else cat
   fi
 }
@@ -207,10 +212,11 @@ ts_filter () {
 # Adds color to the ts stream format.
 ts_color () {
   if [ true = "$TS_COLOR" ]
-  then awk $ts_awk_opts -v norm="$TS_NORM" -v pass="$TS_PASS" -v fail="$TS_FAIL" -v noex="" '
+  then awk $ts_awk_opts -v norm="$TS_NORM" -v pass="$TS_PASS" \
+	  -v skip="$TS_SKIP" -v fail="$TS_FAIL" '
     /^P / { sub("P [[]", "[" pass); sub("]", norm "]"); }
     /^F / { sub("F [[]", "[" fail); sub("]", norm "]"); }
-    /^X / { sub("X [[]", "[" noex); sub("]", norm "]"); }
+    /^S / { sub("S [[]", "[" skip); sub("]", norm "]"); }
     { print $0; fflush(); }'
   else cat
   fi
@@ -221,7 +227,7 @@ ts_format () {
   if [ true = "$TS_COLOR" ]
   then ts_color
   else awk $ts_awk_opts '
-    /^[PFX] / { status=$1; sub(". ", ""); }
+    /^[PFS] / { status=$1; sub(". ", ""); }
     /^$/      { print status; }
     { print $0; fflush(); }'
   fi
@@ -230,9 +236,10 @@ ts_format () {
 # Prints the summary for the tests and returns with the correct status.
 ts_print_status () {
   awk -v nsec="$1" '
-BEGIN { npass=nfail=0 }
-      { npass += $1; nfail += $2; }
-END   { printf("%d pass %d fail %d s\n", npass, nfail, nsec); if(nfail > 0) exit 1 }
+BEGIN { npass=nskip=nfail=0 }
+      { npass += $1; nfail+= $2; nskip += $3; }
+	  END { printf("%d pass %d fail %d skip %d s\n",
+	  npass, nfail, nskip, nsec); if(nfail > 0) exit 1 }
 ' < "$ts_status_file"
 
   ts_exitstatus=$?
@@ -304,9 +311,11 @@ ts_run_test_suite () {
     IFS=:
     ts_list $ts_test_file
   done |
-  while read ts_test_name ts_test_desc
+  while read ts_test ts_test_desc
   do
+    ts_test_name="$ts_test"
     ts_test_dir="$TS_TMP_DIR/$ts_test_case/$ts_test_name"
+    mkdir -p "$ts_test_dir"
     printf "[%s] %s\n" "$ts_test_desc" "$ts_test_name"
 
     if [ execute = "$TS_REPORT" ]
@@ -319,12 +328,18 @@ ts_run_test_suite () {
       # * a zero exit status is considered a pass, otherwise fail
       # * capture as a variable to calculate length
       # * use a subprocess to prevent leakage (ex set -x)
-      if ts_stdout=$(
+      ts_stdout=$(
         if [ verbose = "$TS_MODE" ]
         then (ts_run_test 2>&1)
         else (ts_run_test 2>/dev/null)
         fi
-        )
+        ); retcode=$?
+      # Check to see if the test we're running has been marked as being
+      # skipped; the test's name appears in the skip file if so.
+      grep -q "$ts_test_name" "$ts_skip_file" 2>/dev/null; is_test_skipped=$?
+      if [ "$is_test_skipped" -eq 0 -a "$retcode" -eq 0 ]
+      then ts_status=S
+      elif [ "$retcode" -eq 0 -a "$is_test_skipped" -ne 0 ]
       then ts_status=P
       else ts_status=F
       fi
@@ -332,6 +347,13 @@ ts_run_test_suite () {
       printf "%s %d\n%s\n" "$ts_status" "${#ts_stdout}" "$ts_stdout"
     fi
   done | ts_report
+}
+
+skip () {
+  echo "$ts_test_name" >>"$ts_skip_file"
+  local reason=${1:-"no reason given"}
+  printf "$reason"
+  exit 0
 }
 
 ts_src_test_files () {
@@ -367,11 +389,11 @@ ts_run_test_files () {
         then ./"$ts_test_file" -w
         else "$ts_test_file" -w
         fi
-      else printf "[%s] not executable\nX 0\n\n" "$ts_test_file"
+      else printf "[%s] not executable\nS 0\n\n" "$ts_test_file"
       fi
     elif [ x- = x"$ts_test_file" ]
     then cat
-    else printf "[%s] not a file\nX 0\n\n" "$ts_test_file"
+    else printf "[%s] not a file\nS 0\n\n" "$ts_test_file"
     fi
   done | ts_report
 }

--- a/man/man1/ts.1
+++ b/man/man1/ts.1
@@ -73,7 +73,7 @@ Show passing outputs, which are normally filtered\.
 .
 .TP
 \fB\-c\fR
-Colorize output\. (green/red/yellow \- pass/fail/not\-executable)
+Colorize output\. (green/red/yellow \- pass/fail/skip)
 .
 .TP
 \fB\-d\fR
@@ -136,6 +136,11 @@ Exit 1 unless the variables EXPECTED and ACTUAL are the same\. Reads from stdin 
 .IP
 Using assert_output in a pipeline is often convenient, but be careful you don\'t expect a failing assert_output to exit your test case as, in that case, it will only exit the pipeline\. See the EXAMPLES section for more details\.
 .
+.TP
+\fBskip REASON
+Skips the given test, printing the given REASON.
+.
+.IP
 .P
 \fBts\fR reserves all function names starting with \'ts_\' for internal use\.
 .
@@ -207,8 +212,8 @@ Passing tests\.
 Failing tests\.
 .
 .TP
-\fBTS_NOEX\fR (yellow)
-Non\-executable test files\.
+\fBTS_SKIP\fR (yellow)
+Skipped tests\.
 .
 .TP
 \fBTS_NORM\fR (normal)

--- a/test/examples/skip
+++ b/test/examples/skip
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+. test/helper
+
+test_skip_no_reason () {
+  skip
+}
+
+test_skip_with_reason () {
+  skip "Skipping..."
+}
+
+. ts

--- a/test/suite
+++ b/test/suite
@@ -10,12 +10,13 @@ export TS_TMP_DIR="$ts_test_dir"
 assert_example () {
 example_file="$1"
 
-ts -s "$example_file" | 
+ts -s "$example_file" |
 normalize_stream |
 assert_output "$(
 sed -ne '
 /^# PASS/,/^[^#]/s/# //p
 /^# FAIL/,/^[^#]/s/# //p
+/^# SKIP/,/^[^#]/s/# //p
 ' "$example_file" | 
 normalize_stream
 )
@@ -26,6 +27,7 @@ normalize_stream () {
 sed -e '
 /^P/s/.*/PASS/
 /^F/s/.*/FAIL/
+/^S/s/.*/SKIP/
 /^$/d
 ' 
 }
@@ -125,16 +127,16 @@ P [test/examples/abc:3] test_a
 
 test_ts_reports_non_executable_files () {
 ts -s test/nox | assert_output "\
-X [test/nox] not executable
+S [test/nox] not executable
 
 "
 }
 
 test_ts_reports_non_files () {
 ts -s test test/miss | assert_output "\
-X [test] not a file
+S [test] not a file
 
-X [test/miss] not a file
+S [test/miss] not a file
 
 "
 }
@@ -206,7 +208,7 @@ F [./test/examples/abc:15] test_c
 
 test_ts_does_not_print_passing_tests_by_default () {
 ts test/examples/abc 2>&1 |
-sed -e '$ s/[-0-9]\{1,\} s/# s/' |
+sed -e '$ s/[-0-9]\{1,\} s$/# s/' |
 assert_output "\
 ..F
 
@@ -214,13 +216,13 @@ assert_output "\
   c
 F
 
-2 pass 1 fail # s
+2 pass 1 fail 0 skip # s
 "
 }
 
 test_ts_a_option_prints_all_tests () {
 ts -a test/examples/abc 2>&1 |
-sed -e '$ s/[-0-9]\{1,\} s/# s/' |
+sed -e '$ s/[-0-9]\{1,\} s$/# s/' |
 assert_output "\
 ..F
 
@@ -236,13 +238,13 @@ P
   c
 F
 
-2 pass 1 fail # s
+2 pass 1 fail 0 skip # s
 "
 }
 
 test_script_does_not_print_passing_tests_by_default () {
 ./test/examples/abc 2>&1 |
-sed -e '$ s/[-0-9]\{1,\} s/# s/' |
+sed -e '$ s/[-0-9]\{1,\} s$/# s/' |
 assert_output "\
 ..F
 
@@ -250,13 +252,13 @@ assert_output "\
   c
 F
 
-2 pass 1 fail # s
+2 pass 1 fail 0 skip # s
 "
 }
 
 test_script_a_option_prints_all_tests () {
 ./test/examples/abc -a 2>&1 |
-sed -e '$ s/[-0-9]\{1,\} s/# s/' |
+sed -e '$ s/[-0-9]\{1,\} s$/# s/' |
 assert_output "\
 ..F
 
@@ -272,7 +274,7 @@ P
   c
 F
 
-2 pass 1 fail # s
+2 pass 1 fail 0 skip # s
 "
 }
 
@@ -384,7 +386,7 @@ assert_status 8 $?
 
 test_ts_m_option_monitors_output () {
 ts -am test/examples/abc 2>&1 |
-sed -e '$ s/[-0-9]\{1,\} s/# s/' |
+sed -e '$ s/[-0-9]\{1,\} s$/# s/' |
 assert_output "\
 ..F
 
@@ -400,13 +402,13 @@ P
   c
 F
 
-2 pass 1 fail # s
+2 pass 1 fail 0 skip # s
 "
 }
 
 test_script_m_option_monitors_output () {
 ./test/examples/abc -a -m 2>&1 |
-sed -e "s/[-0-9]\{1,\} s/# s/" |
+sed -e "s/[-0-9]\{1,\} s$/# s/" |
 assert_output "\
 ..F
 
@@ -422,7 +424,7 @@ P
   c
 F
 
-2 pass 1 fail # s
+2 pass 1 fail 0 skip # s
 "
 }
 
@@ -701,6 +703,21 @@ cat | assert_output ""
 test_ts_allows_exit_trap () {
 trap "exit 0" EXIT
 exit 1
+}
+
+#
+# skip test
+#
+
+test_ts_skip () {
+ts -s test/examples/skip | assert_output "\
+S [test/examples/skip:5] test_skip_no_reason
+  no reason given
+
+S [test/examples/skip:9] test_skip_with_reason
+  Skipping...
+
+"
 }
 
 #


### PR DESCRIPTION
Add a mechanism for skipping tests.  Useful for marking tests as half-written, etc.

This reuses the TS_NOEX output which seems to be a relic of some older revision, but we can reuse it in the case of skipping tests.