### PR TITLE
Allow set -u in test scripts

### DIFF
--- a/bin/ts
+++ b/bin/ts
@@ -478,7 +478,7 @@ skip () {
 # Run the test files if this script is executed directly.
 if [ ts = "$ts_progname" ]
 then ts_run_test_files "$@"
-elif [ "." = "$1" ]
+elif [ "." = "${1:-}" ]
 then ts_src_test_files "$@"
 else ts_run_test_suite "$@"
 fi

--- a/test/examples/set_u
+++ b/test/examples/set_u
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -u
+
+. test/helper
+# PASS
+test_set_u() {
+	true
+}
+
+. ts

--- a/test/suite
+++ b/test/suite
@@ -831,6 +831,10 @@ trap "exit 0" EXIT
 exit 1
 }
 
+test_ts_allows_set_u_in_tests() {
+	assert_example test/examples/set_u
+}
+
 #
 # skip test
 #


### PR DESCRIPTION
If test scripts (or scripts included from them) set the flag -u to treat unset variables as an error when substituting, `ts` was failing when accessing `$1`, which causes not to run any test at all.